### PR TITLE
fix(ghostty): bin paths not being updated correctly

### DIFF
--- a/ghostty/ghostty.spec
+++ b/ghostty/ghostty.spec
@@ -51,9 +51,9 @@ Requires: zlib-ng
 
 
 %build
-zig build \
+DESTDIR=%{buildroot} zig build \
     --summary all \
-    --prefix "%{buildroot}%{_prefix}" \
+    --prefix "%{_prefix}" \
     -Dversion-string=%{version}-%{release} \
     -Doptimize=ReleaseFast \
     -Dcpu=baseline \


### PR DESCRIPTION
Fixes an issue where the paths in the generated files uses a build path rather than the expected bin path, as outlined in #58.