### PR TITLE
chore(ghostty): bump release number to 2 for ghostty

### DIFF
--- a/ghostty/ghostty.spec
+++ b/ghostty/ghostty.spec
@@ -1,6 +1,6 @@
 Name:           ghostty
 Version:        1.2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Fast, feature-rich, and cross-platform terminal emulator that uses platform-native UI and GPU acceleration
 
 


### PR DESCRIPTION
To trigger update for users that have installed the release before #60.