### PR TITLE
Remove ghostty terminfo on all versions higher than or equal to 42

### DIFF
--- a/ghostty/ghostty.spec
+++ b/ghostty/ghostty.spec
@@ -60,7 +60,7 @@ DESTDIR=%{buildroot} zig build \
     -Dpie=true \
     -Demit-docs
 
-%if 0%{?fedora} == 42
+%if 0%{?fedora} >= 42
     rm -f "%{buildroot}%{_prefix}/share/terminfo/g/ghostty"
 %endif
 


### PR DESCRIPTION
Fixes #65.
Was not tested (yet), because I don't have a working Fedora 43 install, but it should work in theory.