### PR TITLE
Fix build not finishing on Fedora 43 and Rawhide

### DIFF
--- a/ghostty/ghostty.spec
+++ b/ghostty/ghostty.spec
@@ -101,7 +101,7 @@ DESTDIR=%{buildroot} zig build \
 %{_prefix}/share/systemd/user/app-com.mitchellh.ghostty.service
 
 %{_prefix}/share/terminfo/x/xterm-ghostty
-%if 0%{?fedora} != 42
+%if 0%{?fedora} < 42
     %{_prefix}/share/terminfo/g/ghostty
 %endif
 


### PR DESCRIPTION
Looks like the file that was getting deleted on Fedora 42 (and, as of #66, on higher versions) was referenced later in the process. This PR fixes builds failing because the file was not found on Fedora 43 and Rawhide.