### PR TITLE
ghostty: enable debug symbols in RPM builds

### DIFF
--- a/ghostty/ghostty.spec
+++ b/ghostty/ghostty.spec
@@ -1,6 +1,6 @@
 Name:           ghostty
 Version:        1.3.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Fast, feature-rich, and cross-platform terminal emulator that uses platform-native UI and GPU acceleration
 
 
@@ -65,6 +65,7 @@ DESTDIR=%{buildroot} zig build \
     -Doptimize=ReleaseFast \
     -Dcpu=baseline \
     -Dpie=true \
+    -Dstrip=false \
     -Demit-docs \
     -Demit-themes=true
 


### PR DESCRIPTION
Pass -Dstrip=false to the Zig build so that rpmbuild can extract debug symbols into ghostty-debuginfo and ghostty-debugsource subpackages.

Without this flag, -Doptimize=ReleaseFast defaults to stripping the binary, which also disables unwind tables and omits frame pointers (https://github.com/ghostty-org/ghostty/blob/6590196661f769dd8f2b3e85d6c98262c4ec5b3b/src/build/GhosttyExe.zig#L20-L22). This makes crash backtraces from Linux bug reports nearly useless.

The openSUSE package already passes -Dstrip=false and successfully produces debuginfo packages. The -Dstrip option was added to Ghostty specifically for this use case:
* https://github.com/ghostty-org/ghostty/pull/3945
* https://github.com/ghostty-org/ghostty/discussions/4330
* https://github.com/ghostty-org/ghostty/discussions/2671