### PR TITLE
fix(voxtype): RPM checksum updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,6 +18,15 @@
       allowedVersions: '/^44$/',
     },
   ],
+  customDatasources: {
+    'voxtype-rpm': {
+      defaultRegistryUrlTemplate: 'https://api.github.com/repos/peteonrails/voxtype/releases',
+      format: 'json',
+      transformTemplates: [
+        '($rpmName:=function($release){"voxtype-" & $replace($release.tag_name,/^v/,"") & "-1.x86_64.rpm"};$rpmAsset:=function($release){($filter($release.assets,function($asset){$asset.name=$rpmName($release) and $contains($asset.digest,/^sha256:[0-9a-f]{64}$/)}))[0]};{"releases":$map($filter($,function($release){$exists($rpmAsset($release))}),function($release){($version:=$replace($release.tag_name,/^v/,"");$asset:=$rpmAsset($release);{"version":$version,"releaseTimestamp":$release.published_at,"changelogUrl":$release.html_url,"sourceUrl":$release.html_url,"digest":$replace($asset.digest,/^sha256:/,"")})}),"sourceUrl":"https://github.com/peteonrails/voxtype","homepage":"https://voxtype.io"})',
+      ],
+    },
+  },
   customManagers: [
     {
       customType: 'regex',
@@ -235,10 +244,12 @@
         '/^voxtype/voxtype\\.spec$/',
       ],
       matchStrings: [
-        'Version:\\s*(?<currentValue>\\S+)',
+        '(?<checksumPrefix>%global\\s+upstream_rpm_sha256\\s+)(?<currentDigest>[0-9a-f]{64})(?<versionPrefix>\\n(?:.*\\n)*?Version:\\s*)(?<currentValue>\\S+)',
       ],
       depNameTemplate: 'peteonrails/voxtype',
-      datasourceTemplate: 'github-releases',
+      datasourceTemplate: 'custom.voxtype-rpm',
+      versioningTemplate: 'semver',
+      autoReplaceStringTemplate: '{{{checksumPrefix}}}{{{newDigest}}}{{{versionPrefix}}}{{{newValue}}}',
     },
     {
       customType: 'regex',

--- a/.github/workflows/spec-guards.yaml
+++ b/.github/workflows/spec-guards.yaml
@@ -9,6 +9,7 @@ on:
       - scripts/fix-spec-guards.sh
       - scripts/test-check-spec-guards.sh
       - scripts/test-spec-helper-scripts.sh
+      - scripts/test-voxtype-renovate-checksum.sh
       - .github/renovate.json5
       - .github/spec-build-targets.json
       - .github/workflows/spec-guards.yaml
@@ -35,5 +36,7 @@ jobs:
         run: scripts/test-check-spec-guards.sh
       - name: Run spec helper tests
         run: scripts/test-spec-helper-scripts.sh
+      - name: Run Voxtype Renovate checksum tests
+        run: scripts/test-voxtype-renovate-checksum.sh
       - name: Run spec guards
         run: scripts/check-spec-guards.sh

--- a/scripts/test-voxtype-renovate-checksum.sh
+++ b/scripts/test-voxtype-renovate-checksum.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+failures=0
+
+fail() {
+    local message=$1
+
+    printf 'not ok - %s\n' "$message"
+    failures=$((failures + 1))
+}
+
+pass() {
+    local message=$1
+
+    printf 'ok - %s\n' "$message"
+}
+
+assert_grep() {
+    local pattern=$1
+    local file=$2
+    local message=$3
+
+    if grep -Eq "$pattern" "$file"; then
+        pass "$message"
+    else
+        fail "$message"
+    fi
+}
+
+assert_no_grep() {
+    local pattern=$1
+    local file=$2
+    local message=$3
+
+    if grep -Eq "$pattern" "$file"; then
+        fail "$message"
+    else
+        pass "$message"
+    fi
+}
+
+assert_grep '^%global[[:space:]]+upstream_rpm_sha256[[:space:]]+[0-9a-f]{64}$' \
+    voxtype/voxtype.spec \
+    'voxtype spec pins the upstream RPM sha256'
+assert_no_grep '^Source1:[[:space:]]+.*SHA256SUMS' \
+    voxtype/voxtype.spec \
+    'voxtype spec does not depend on upstream SHA256SUMS'
+assert_grep '%\{upstream_rpm_sha256\}' \
+    voxtype/voxtype.spec \
+    'voxtype prep verifies the pinned RPM sha256'
+assert_grep '%\{_datadir\}/voxtype' \
+    voxtype/voxtype.spec \
+    'voxtype spec owns upstream app data payloads'
+
+assert_grep "datasourceTemplate: 'custom\.voxtype-rpm'" \
+    .github/renovate.json5 \
+    'renovate uses the Voxtype RPM custom datasource'
+assert_grep 'currentDigest' \
+    .github/renovate.json5 \
+    'renovate captures the current RPM sha256 digest'
+assert_grep 'autoReplaceStringTemplate' \
+    .github/renovate.json5 \
+    'renovate replaces version and RPM sha256 together'
+assert_grep 'rpmName:=function.*-1\.x86_64\.rpm' \
+    .github/renovate.json5 \
+    'renovate filters releases to the matching RPM asset'
+assert_grep 'sha256:\[0-9a-f\]\{64\}' \
+    .github/renovate.json5 \
+    'renovate emits only releases with a valid sha256 asset digest'
+
+exit "$failures"

--- a/voxtype/voxtype.spec
+++ b/voxtype/voxtype.spec
@@ -1,16 +1,16 @@
 %global upstream_release 1
 %global upstream_rpm %{name}-%{version}-%{upstream_release}.x86_64.rpm
+%global upstream_rpm_sha256 a0a2630eaa4315fabd5f5d292b1cc230ed11f9edcf154be1c2ad346f01c71871
 %global debug_package %{nil}
 
 Name:           voxtype
-Version:        0.7.2
+Version:        0.7.3
 Release:        1%{?dist}
 Summary:        Push-to-talk voice-to-text for Linux
 
 License:        MIT
 URL:            https://voxtype.io
 Source0:        https://github.com/peteonrails/voxtype/releases/download/v%{version}/%{upstream_rpm}
-Source1:        https://github.com/peteonrails/voxtype/releases/download/v%{version}/SHA256SUMS.txt
 
 ExclusiveArch:  x86_64
 AutoReqProv:    no
@@ -38,16 +38,10 @@ not rebuild Voxtype from source.
 %prep
 %setup -q -c -T
 
-expected_sum="$(awk -v rpm='%{upstream_rpm}' '$2 == rpm { print $1 }' %{SOURCE1})"
-if [ -z "$expected_sum" ]; then
-    echo "ERROR: %{upstream_rpm} is missing from %{SOURCE1}" >&2
-    exit 1
-fi
-
 actual_sum="$(sha256sum %{SOURCE0} | awk '{ print $1 }')"
-if [ "$expected_sum" != "$actual_sum" ]; then
+if [ "%{upstream_rpm_sha256}" != "$actual_sum" ]; then
     echo "ERROR: checksum verification failed for %{upstream_rpm}" >&2
-    echo "Expected: $expected_sum" >&2
+    echo "Expected: %{upstream_rpm_sha256}" >&2
     echo "Actual:   $actual_sum" >&2
     exit 1
 fi
@@ -194,6 +188,7 @@ echo ""
 %doc %{_docdir}/voxtype/README.md
 %{_datadir}/fish/vendor_completions.d/voxtype.fish
 %{_mandir}/man1/voxtype*.1*
+%{_datadir}/voxtype
 %{_datadir}/zsh/site-functions/_voxtype
 
 %changelog


### PR DESCRIPTION
Use the GitHub release asset digest as the Renovate-updated checksum source so Voxtype version bumps keep strict RPM verification without depending on stale upstream SHA256SUMS files.