### PR TITLE
feat(zennotes): repackage upstream RPM

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,11 +26,11 @@
         '($rpmName:=function($release){"voxtype-" & $replace($release.tag_name,/^v/,"") & "-1.x86_64.rpm"};$rpmAsset:=function($release){($filter($release.assets,function($asset){$asset.name=$rpmName($release) and $contains($asset.digest,/^sha256:[0-9a-f]{64}$/)}))[0]};{"releases":$map($filter($,function($release){$exists($rpmAsset($release))}),function($release){($version:=$replace($release.tag_name,/^v/,"");$asset:=$rpmAsset($release);{"version":$version,"releaseTimestamp":$release.published_at,"changelogUrl":$release.html_url,"sourceUrl":$release.html_url,"digest":$replace($asset.digest,/^sha256:/,"")})}),"sourceUrl":"https://github.com/peteonrails/voxtype","homepage":"https://voxtype.io"})',
       ],
     },
-    'zennotes-deb': {
+    'zennotes-rpm': {
       defaultRegistryUrlTemplate: 'https://api.github.com/repos/ZenNotes/zennotes/releases',
       format: 'json',
       transformTemplates: [
-        '($debName:=function($release){"ZenNotes-" & $replace($release.tag_name,/^v/,"") & "-linux-amd64.deb"};$debAsset:=function($release){($filter($release.assets,function($asset){$asset.name=$debName($release) and $contains($asset.digest,/^sha256:[0-9a-f]{64}$/)}))[0]};{"releases":$map($filter($,function($release){$contains($release.tag_name,/^v/) and $exists($debAsset($release))}),function($release){($version:=$replace($release.tag_name,/^v/,"");$asset:=$debAsset($release);{"version":$version,"releaseTimestamp":$release.published_at,"changelogUrl":$release.html_url,"sourceUrl":$release.html_url,"digest":$replace($asset.digest,/^sha256:/,"")})}),"sourceUrl":"https://github.com/ZenNotes/zennotes","homepage":"https://github.com/ZenNotes/zennotes"})',
+        '($rpmName:=function($release){"ZenNotes-" & $replace($release.tag_name,/^v/,"") & "-linux-x86_64.rpm"};$rpmAsset:=function($release){($filter($release.assets,function($asset){$asset.name=$rpmName($release) and $contains($asset.digest,/^sha256:[0-9a-f]{64}$/)}))[0]};{"releases":$map($filter($,function($release){$contains($release.tag_name,/^v/) and $exists($rpmAsset($release))}),function($release){($version:=$replace($release.tag_name,/^v/,"");$asset:=$rpmAsset($release);{"version":$version,"releaseTimestamp":$release.published_at,"changelogUrl":$release.html_url,"sourceUrl":$release.html_url,"digest":$replace($asset.digest,/^sha256:/,"")})}),"sourceUrl":"https://github.com/ZenNotes/zennotes","homepage":"https://github.com/ZenNotes/zennotes"})',
       ],
     },
   },
@@ -263,10 +263,10 @@
         '/^zennotes/zennotes\\.spec$/',
       ],
       matchStrings: [
-        '(?<checksumPrefix>%global\\s+upstream_deb_sha256\\s+)(?<currentDigest>[0-9a-f]{64})(?<versionPrefix>\\n(?:.*\\n)*?Version:\\s*)(?<currentValue>\\S+)',
+        '(?<checksumPrefix>%global\\s+upstream_rpm_sha256\\s+)(?<currentDigest>[0-9a-f]{64})(?<versionPrefix>\\n(?:.*\\n)*?Version:\\s*)(?<currentValue>\\S+)',
       ],
       depNameTemplate: 'ZenNotes/zennotes',
-      datasourceTemplate: 'custom.zennotes-deb',
+      datasourceTemplate: 'custom.zennotes-rpm',
       versioningTemplate: 'semver',
     },
     {

--- a/scripts/test-zennotes-renovate-checksum.sh
+++ b/scripts/test-zennotes-renovate-checksum.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Guard ZenNotes' downstream RPM spec against Renovate updates that change the
-# upstream version without also updating the pinned DEB checksum. Upstream does
+# upstream version without also updating the pinned RPM checksum. Upstream does
 # not publish a standalone SHA256SUMS file, so Renovate must read GitHub release
 # asset digests and update both spec fields together for COPR builds to keep
-# verifying the exact DEB payload they repackage.
+# verifying the exact RPM payload they repackage.
 set -euo pipefail
 
 failures=0
@@ -45,18 +45,44 @@ assert_no_grep() {
     fi
 }
 
-assert_grep '^%global[[:space:]]+upstream_deb_sha256[[:space:]]+[0-9a-f]{64}$' \
+assert_grep '^%global[[:space:]]+upstream_rpm_sha256[[:space:]]+[0-9a-f]{64}$' \
     zennotes/zennotes.spec \
-    'zennotes spec pins the upstream DEB sha256'
+    'zennotes spec pins the upstream RPM sha256'
 assert_no_grep '^Source1:[[:space:]]+.*SHA256SUMS' \
     zennotes/zennotes.spec \
     'zennotes spec does not depend on upstream SHA256SUMS'
-assert_grep '%\{upstream_deb_sha256\}' \
+assert_grep '%\{upstream_rpm_sha256\}' \
     zennotes/zennotes.spec \
-    'zennotes prep verifies the pinned DEB sha256'
-assert_grep '%\{_bindir\}/zen' \
+    'zennotes prep verifies the pinned RPM sha256'
+assert_grep 'FILEMODES:octal.*FILENAMES' \
     zennotes/zennotes.spec \
-    'zennotes spec provides the bundled zen CLI wrapper'
+    'zennotes validates RPM entry types before extraction'
+assert_grep '^BuildRequires:[[:space:]]+bsdtar$' \
+    zennotes/zennotes.spec \
+    'zennotes uses the safe libarchive extractor'
+assert_grep 'rpm2cpio .*\| bsdtar -xf - -C payload' \
+    zennotes/zennotes.spec \
+    'zennotes extracts the RPM payload with bsdtar containment checks'
+assert_no_grep 'rpm2cpio .*\| cpio' \
+    zennotes/zennotes.spec \
+    'zennotes does not extract the RPM payload with GNU cpio'
+if grep -Eq '^Version:[[:space:]]+2\.13\.1$' zennotes/zennotes.spec; then
+    assert_grep '^Release:[[:space:]]+2%\{\?dist\}$' \
+        zennotes/zennotes.spec \
+        'zennotes same-version migration increments the downstream release'
+fi
+assert_grep '%\{_bindir\}/zennotes' \
+    zennotes/zennotes.spec \
+    'zennotes spec provides the desktop launcher'
+assert_no_grep '^%\{_bindir\}/zen$|ln -s .*%\{_bindir\}/zen([[:space:]]|$)' \
+    zennotes/zennotes.spec \
+    'zennotes spec does not package the legacy zen command'
+assert_no_grep '^%\{_bindir\}/zn$|ln -s .*%\{_bindir\}/zn([[:space:]]|$)' \
+    zennotes/zennotes.spec \
+    'zennotes spec leaves zn installation to upstream Settings'
+assert_grep 'test -x %\{buildroot\}%\{app_dir\}/resources/zen' \
+    zennotes/zennotes.spec \
+    'zennotes spec retains the bundled CLI wrapper for upstream Settings'
 assert_grep '^%global[[:space:]]+app_dir[[:space:]]+%\{_libdir\}/%\{name\}$' \
     zennotes/zennotes.spec \
     'zennotes app payload installs under the Fedora private libdir'
@@ -69,15 +95,21 @@ assert_no_grep 'ln -s .*opt/ZenNotes' \
 assert_grep 'ln -s \.\./%\{_lib\}/%\{name\}/ZenNotes[[:space:]]+%\{buildroot\}%\{_bindir\}/zennotes' \
     zennotes/zennotes.spec \
     'zennotes desktop launcher symlink targets relocated app relatively'
-assert_grep 'ln -s \.\./%\{_lib\}/%\{name\}/resources/zen[[:space:]]+%\{buildroot\}%\{_bindir\}/zen' \
-    zennotes/zennotes.spec \
-    'zennotes CLI symlink targets relocated wrapper relatively'
 assert_grep 'Exec=%\{app_dir\}/ZenNotes %U' \
     zennotes/zennotes.spec \
     'zennotes desktop file Exec points at relocated app path'
-assert_grep 'find %\{buildroot\}%\{app_dir\} -perm /6000' \
+assert_grep 'find %\{buildroot\} -perm /6000' \
     zennotes/zennotes.spec \
     'zennotes check audits privileged files in relocated payload'
+assert_grep 'icon_entry_count' \
+    zennotes/zennotes.spec \
+    'zennotes requires the exact upstream icon inventory'
+assert_grep "stat -c '%%a'.*chrome-sandbox" \
+    zennotes/zennotes.spec \
+    'zennotes check requires the exact sandbox mode'
+assert_grep '^%attr\(4755,root,root\)[[:space:]]+%\{app_dir\}/chrome-sandbox$' \
+    zennotes/zennotes.spec \
+    'zennotes package metadata requires root sandbox ownership'
 assert_grep 'rm -f %\{buildroot\}%\{app_dir\}/LICENSE' \
     zennotes/zennotes.spec \
     'zennotes removes the duplicate bundled app license'
@@ -114,11 +146,11 @@ assert_zennotes_manager_grep() {
     fi
 }
 
-assert_grep "datasourceTemplate: 'custom\.zennotes-deb'" \
+assert_grep "datasourceTemplate: 'custom\.zennotes-rpm'" \
     .github/renovate.json5 \
-    'renovate uses the ZenNotes DEB custom datasource'
-assert_zennotes_manager_grep 'upstream_deb_sha256.*currentDigest' \
-    'renovate captures the current DEB sha256 digest'
+    'renovate uses the ZenNotes RPM custom datasource'
+assert_zennotes_manager_grep 'upstream_rpm_sha256.*currentDigest' \
+    'renovate captures the current RPM sha256 digest'
 if awk '
     /^    \{/ {
         block = $0 ORS
@@ -141,14 +173,14 @@ if awk '
     }
     END { exit found ? 0 : 1 }
 ' .github/renovate.json5; then
-    fail 'renovate lets default autoreplace update version and DEB sha256 together'
+    fail 'renovate lets default autoreplace update version and RPM sha256 together'
 else
-    pass 'renovate lets default autoreplace update version and DEB sha256 together'
+    pass 'renovate lets default autoreplace update version and RPM sha256 together'
 fi
-assert_grep 'debName:=function.*linux-amd64\.deb' \
+assert_grep 'rpmName:=function.*linux-x86_64\.rpm' \
     .github/renovate.json5 \
-    'renovate filters releases to the matching Linux amd64 DEB asset'
-assert_grep 'debName:=function.*sha256:\[0-9a-f\]\{64\}' \
+    'renovate filters releases to the matching Linux x86_64 RPM asset'
+assert_grep 'rpmName:=function.*sha256:\[0-9a-f\]\{64\}' \
     .github/renovate.json5 \
     'renovate emits only releases with a valid sha256 asset digest'
 assert_grep "\\\$contains\\(\\\$release\\.tag_name,/\\^v/\\)" \

--- a/zennotes/README.md
+++ b/zennotes/README.md
@@ -10,14 +10,14 @@
 [ZenNotes](https://github.com/ZenNotes/zennotes) packaged for Fedora and
 published to [copr](https://copr.fedorainfracloud.org/coprs/scottames/zennotes).
 
-This package republishes the official upstream GitHub Release DEB so Fedora can
+This package republishes the official upstream GitHub Release RPM so Fedora can
 install and update ZenNotes through normal DNF/COPR metadata.
 
 >[!WARNING]
 > This copr is intended for my personal use only.
 > Use at your own risk.
 >
-> - This package uses upstream's prebuilt Electron DEB; it does not rebuild
+> - This package uses upstream's prebuilt Electron RPM; it does not rebuild
 >   ZenNotes from source.
 > - Updates should be installed through DNF/COPR, not the app's upstream
 >   self-updater.
@@ -61,6 +61,9 @@ sudo dnf upgrade zennotes
 
 ## Notes
 
-- Fedora builds are x86_64 only for now, matching upstream's Linux DEB asset.
-- The package provides `zennotes` for the desktop app and `zen` for the bundled
-  ZenNotes CLI wrapper.
+- Fedora builds are x86_64 only for now, matching the selected upstream RPM
+  asset.
+- The package provides `zennotes` for the desktop app.
+- To enable the bundled `zn` CLI, open **Settings -> CLI** in ZenNotes and
+  select **Install**. ZenNotes manages that command separately; the RPM owns
+  neither `zn` nor the legacy `zen` command.

--- a/zennotes/zennotes.spec
+++ b/zennotes/zennotes.spec
@@ -1,29 +1,27 @@
-%global upstream_deb ZenNotes-%{version}-linux-amd64.deb
-%global upstream_deb_sha256 3d644a33de85a77831b25f2c2944b1cbd53a1287c48ef157a8341c436f49f5c3
+%global upstream_rpm ZenNotes-%{version}-linux-x86_64.rpm
+%global upstream_rpm_sha256 1f1f61cfec06333fb6ba9dca11fc049c7dc748e9bf006dddee0751da15f18b82
 %global app_dir %{_libdir}/%{name}
 %global debug_package %{nil}
 
 Name:           zennotes
 Version:        2.13.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Markdown notes app with local-first vaults
 
 License:        MIT
 URL:            https://github.com/ZenNotes/zennotes
-Source0:        https://github.com/ZenNotes/zennotes/releases/download/v%{version}/%{upstream_deb}
+Source0:        https://github.com/ZenNotes/zennotes/releases/download/v%{version}/%{upstream_rpm}
 Source1:        https://raw.githubusercontent.com/ZenNotes/zennotes/v%{version}/LICENSE
 
 ExclusiveArch:  x86_64
 
-BuildRequires:  binutils
 BuildRequires:  coreutils
+BuildRequires:  bsdtar
 BuildRequires:  desktop-file-utils
 BuildRequires:  findutils
-BuildRequires:  gzip
+BuildRequires:  gawk
+BuildRequires:  rpm
 BuildRequires:  shared-mime-info
-BuildRequires:  tar
-BuildRequires:  xz
-BuildRequires:  zstd
 
 Requires:       at-spi2-core
 Requires:       gtk3
@@ -45,7 +43,7 @@ Recommends:     libappindicator-gtk3
 %description
 ZenNotes is a local-first Markdown notes app with desktop, CLI, and MCP support.
 
-This COPR package republishes the official upstream GitHub Release DEB so
+This COPR package republishes the official upstream GitHub Release RPM so
 Fedora can install and update ZenNotes through normal DNF/COPR metadata. It does
 not rebuild ZenNotes from source.
 
@@ -53,25 +51,32 @@ not rebuild ZenNotes from source.
 %setup -q -c -T
 
 actual_sum="$(sha256sum %{SOURCE0} | awk '{ print $1 }')"
-if [ "%{upstream_deb_sha256}" != "$actual_sum" ]; then
-    echo "ERROR: checksum verification failed for %{upstream_deb}" >&2
-    echo "Expected: %{upstream_deb_sha256}" >&2
+if [ "%{upstream_rpm_sha256}" != "$actual_sum" ]; then
+    echo "ERROR: checksum verification failed for %{upstream_rpm}" >&2
+    echo "Expected: %{upstream_rpm_sha256}" >&2
     echo "Actual:   $actual_sum" >&2
     exit 1
 fi
 
-mkdir payload deb-control
-ar x %{SOURCE0}
+test "$(rpm -qp --qf '%%{NAME}' %{SOURCE0})" = "ZenNotes"
+test "$(rpm -qp --qf '%%{VERSION}' %{SOURCE0})" = "%{version}"
+test "$(rpm -qp --qf '%%{ARCH}' %{SOURCE0})" = "x86_64"
+rpmkeys --checksig %{SOURCE0}
 
-control_archive="$(find . -maxdepth 1 -type f -name 'control.tar.*' -print -quit)"
-data_archive="$(find . -maxdepth 1 -type f -name 'data.tar.*' -print -quit)"
-if [ -z "$control_archive" ] || [ -z "$data_archive" ]; then
-    echo "ERROR: expected control.tar.* and data.tar.* in %{upstream_deb}" >&2
+unexpected_rpm_entry="$(rpm -qp --qf '[%%{FILEMODES:octal}\t%%{FILENAMES}\n]' %{SOURCE0} | awk '
+    $1 ~ /^10[0-7]{4}$/ || $1 ~ /^4[0-7]{4}$/ { next }
+    $1 ~ /^12[0-7]{4}$/ && $2 ~ /^\/usr\/lib\/\.build-id\/[0-9a-f]{2}\/[0-9a-f]+$/ { next }
+    { print $2; exit }
+')"
+if [ -n "$unexpected_rpm_entry" ]; then
+    echo "ERROR: unsafe upstream RPM entry: $unexpected_rpm_entry" >&2
     exit 1
 fi
 
-tar -xf "$control_archive" -C deb-control
-tar -xf "$data_archive" -C payload
+mkdir payload
+rpm2cpio %{SOURCE0} | bsdtar -xf - -C payload \
+    --no-same-owner --no-same-permissions \
+    --exclude './usr/lib/.build-id*' --exclude 'usr/lib/.build-id*'
 
 unexpected_path="$(find payload -mindepth 1 -maxdepth 1 ! -name opt ! -name usr -print -quit)"
 if [ -n "$unexpected_path" ]; then
@@ -80,29 +85,79 @@ if [ -n "$unexpected_path" ]; then
 fi
 
 test -d payload/opt/ZenNotes
+test ! -L payload/opt/ZenNotes
 test -d payload/usr/share/applications
 test -d payload/usr/share/icons/hicolor
 test -d payload/usr/share/mime/packages
+test -f payload/usr/share/applications/ZenNotes.desktop
+test -f payload/usr/share/mime/packages/ZenNotes.xml
+
+unexpected_opt_path="$(find payload/opt -mindepth 1 -maxdepth 1 ! -name ZenNotes -print -quit)"
+if [ -n "$unexpected_opt_path" ]; then
+    echo "ERROR: unexpected upstream /opt path: $unexpected_opt_path" >&2
+    exit 1
+fi
+
+unexpected_usr_path="$(find payload/usr -mindepth 1 -maxdepth 1 ! -name share -print -quit)"
+if [ -n "$unexpected_usr_path" ]; then
+    echo "ERROR: unexpected upstream /usr path: $unexpected_usr_path" >&2
+    exit 1
+fi
+
+unexpected_share_path="$(find payload/usr/share -mindepth 1 -maxdepth 1 \
+    ! -name applications ! -name icons ! -name mime -print -quit)"
+if [ -n "$unexpected_share_path" ]; then
+    echo "ERROR: unexpected upstream /usr/share path: $unexpected_share_path" >&2
+    exit 1
+fi
+
+unexpected_application="$(find payload/usr/share/applications -mindepth 1 \
+    ! -name ZenNotes.desktop -print -quit)"
+unexpected_mime="$(find payload/usr/share/mime/packages -mindepth 1 \
+    ! -name ZenNotes.xml -print -quit)"
+if [ -n "$unexpected_application" ] || [ -n "$unexpected_mime" ]; then
+    echo "ERROR: unexpected upstream desktop or MIME payload" >&2
+    exit 1
+fi
+
+icon_entry_count="$(find payload/usr/share/icons/hicolor -mindepth 1 -printf x | wc -c)"
+test "$icon_entry_count" -eq 24
+for size in 16 24 32 48 64 128 256 512; do
+    icon_dir="payload/usr/share/icons/hicolor/${size}x${size}"
+    test -d "$icon_dir"
+    test ! -L "$icon_dir"
+    test -d "$icon_dir/apps"
+    test ! -L "$icon_dir/apps"
+    test -f "$icon_dir/apps/ZenNotes.png"
+    test ! -L "$icon_dir/apps/ZenNotes.png"
+done
 
 %build
-# Upstream binary DEB repackaging; nothing to build.
+# Upstream binary RPM repackaging; nothing to build.
 
 %install
 mkdir -p %{buildroot}
 
-# Upstream's DEB installs the Electron app under /opt/ZenNotes. On Fedora
+# Upstream's RPM installs the Electron app under /opt/ZenNotes. On Fedora
 # Atomic/rpm-ostree systems /opt is a mutable /var/opt location, so RPM-owned
 # application payloads should live under /usr instead. Keep the upstream
 # payload contents intact, but relocate them into Fedora's private libdir and
 # patch the launchers below to avoid owning or depending on /opt.
-cp -a payload/usr %{buildroot}/
+install -D -m 0644 payload/usr/share/applications/ZenNotes.desktop \
+    %{buildroot}%{_datadir}/applications/ZenNotes.desktop
+install -D -m 0644 payload/usr/share/mime/packages/ZenNotes.xml \
+    %{buildroot}%{_datadir}/mime/packages/ZenNotes.xml
+for size in 16 24 32 48 64 128 256 512; do
+    install -D -m 0644 \
+        "payload/usr/share/icons/hicolor/${size}x${size}/apps/ZenNotes.png" \
+        "%{buildroot}%{_datadir}/icons/hicolor/${size}x${size}/apps/ZenNotes.png"
+done
 install -d %{buildroot}%{app_dir}
 cp -a payload/opt/ZenNotes/. %{buildroot}%{app_dir}/
 
 install -D -m 0644 %{SOURCE1} %{buildroot}%{_licensedir}/%{name}/LICENSE
 mkdir -p %{buildroot}%{_bindir}
 ln -s ../%{_lib}/%{name}/ZenNotes %{buildroot}%{_bindir}/zennotes
-ln -s ../%{_lib}/%{name}/resources/zen %{buildroot}%{_bindir}/zen
 
 # Upstream Linux update metadata points at GitHub AppImage/DEB assets. COPR/DNF
 # should remain the update path for this RPM package.
@@ -123,21 +178,23 @@ test -f %{buildroot}%{app_dir}/resources/cli.js
 test ! -f %{buildroot}%{app_dir}/resources/app-update.yml
 test ! -f %{buildroot}%{app_dir}/resources/package-type
 test -L %{buildroot}%{_bindir}/zennotes
-test -L %{buildroot}%{_bindir}/zen
 test "$(readlink %{buildroot}%{_bindir}/zennotes)" = "../%{_lib}/%{name}/ZenNotes"
-test "$(readlink %{buildroot}%{_bindir}/zen)" = "../%{_lib}/%{name}/resources/zen"
 test -x %{buildroot}%{_bindir}/zennotes
-test -x %{buildroot}%{_bindir}/zen
+test ! -e %{buildroot}%{_bindir}/zen
+test ! -e %{buildroot}%{_bindir}/zn
+test ! -e %{buildroot}/opt
+test -z "$(find %{buildroot} -path '*/.build-id/*' -print -quit)"
 grep -qx 'Exec=%{app_dir}/ZenNotes %U' \
     %{buildroot}%{_datadir}/applications/ZenNotes.desktop
 ! grep -q '/opt/ZenNotes' %{buildroot}%{_datadir}/applications/ZenNotes.desktop
-privileged_files="$(find %{buildroot}%{app_dir} -perm /6000 -printf '%%p\n')"
+privileged_files="$(find %{buildroot} -perm /6000 -printf '%%p\n')"
 expected_privileged_file="%{buildroot}%{app_dir}/chrome-sandbox"
 if [ "$privileged_files" != "$expected_privileged_file" ]; then
     echo "ERROR: unexpected setuid/setgid files in %{app_dir}" >&2
     printf 'Expected:\n%s\nActual:\n%s\n' "$expected_privileged_file" "$privileged_files" >&2
     exit 1
 fi
+test "$(stat -c '%%a' %{buildroot}%{app_dir}/chrome-sandbox)" = 4755
 desktop-file-validate %{buildroot}%{_datadir}/applications/ZenNotes.desktop
 mkdir -p mime-check/mime
 cp -a %{buildroot}%{_datadir}/mime/packages mime-check/mime/
@@ -155,9 +212,7 @@ update-mime-database -n %{_datadir}/mime || :
 
 %files
 %license %{_licensedir}/%{name}/LICENSE
-%doc %{_docdir}/%{name}/changelog.gz
 %{_bindir}/zennotes
-%{_bindir}/zen
 %{_datadir}/applications/ZenNotes.desktop
 %{_datadir}/icons/hicolor/*/apps/ZenNotes.png
 %{_datadir}/mime/packages/ZenNotes.xml


### PR DESCRIPTION
## Summary

- switch ZenNotes sourcing and Renovate automation from the upstream amd64 DEB to the exact x86_64 RPM
- safely extract and validate the upstream payload, relocate the application for Fedora Atomic, and retain only the package-owned `zennotes` launcher
- leave `zn` installation to ZenNotes Settings, remove legacy `zen` ownership, and update package documentation

## Testing

- `scripts/test-zennotes-renovate-checksum.sh`
- `scripts/test-check-spec-guards.sh`
- `scripts/test-spec-helper-scripts.sh`
- `scripts/check-spec-guards.sh`
- `shellcheck scripts/*.sh`
- `actionlint .github/workflows/spec-guards.yaml`
- `git diff --check`
- `rpmspec -P zennotes/zennotes.spec`
- simulated a future ZenNotes version bump with `Release: 1%{?dist}` and reran the focused guard

## Qualification

Local Dagger and container attempts were blocked before `rpmbuild` by sandbox/filesync failures. The PR's Fedora 43 and 44 changed-spec jobs provide the package-build evidence. Fresh-install, 2.13.1-1 upgrade, and Settings-managed `zn` lifecycle checks remain follow-up qualification using successful RPM artifacts.