### PR TITLE
chore(hypr): rebuild libraries for hyprutils 0.14

### DIFF
--- a/hypr/hyprgraphics.spec
+++ b/hypr/hyprgraphics.spec
@@ -1,6 +1,6 @@
 Name:           hyprgraphics
 Version:        0.5.1
-Release:        %autorelease -b11
+Release:        %autorelease -b12
 Summary:        Hyprland graphics / resource utilities
 
 License:        BSD-3-Clause

--- a/hypr/hyprlang.spec
+++ b/hypr/hyprlang.spec
@@ -1,6 +1,6 @@
 Name:           hyprlang
 Version:        0.6.8
-Release:        %autorelease -b10
+Release:        %autorelease -b11
 Summary:        The official implementation library for the hypr config language
 
 License:        LGPL-3.0-only

--- a/hypr/hyprwire.spec
+++ b/hypr/hyprwire.spec
@@ -1,6 +1,6 @@
 Name:           hyprwire
 Version:        0.3.1
-Release:        %autorelease
+Release:        %autorelease -b2
 Summary:        A fast and consistent wire protocol for IPC
 
 License:        BSD-3-Clause


### PR DESCRIPTION
## Summary

- rebuild hyprgraphics against `libhyprutils.so.13`
- rebuild hyprlang against `libhyprutils.so.13`
- rebuild hyprwire against `libhyprutils.so.13`

## Ordering

Merge after hyprutils 0.14.0 is published in the Fedora 43/44 x86_64 COPR repositories. These three packages are independent and form the foundation for the next rebuild wave.

## Verification

- `scripts/check-spec-guards.sh`
- `git diff --check`
- Fedora 43/44 package builds in PR CI