### PR TITLE
chore(hypr): rebuild consumers for hyprutils 0.14

### DIFF
--- a/hypr/hypridle.spec
+++ b/hypr/hypridle.spec
@@ -2,7 +2,7 @@
 
 Name:           hypridle
 Version:        0.1.8
-Release:        %autorelease
+Release:        %autorelease -b2
 Summary:        Hyprland's idle daemon
 License:        BSD-3-Clause
 URL:            https://github.com/hyprwm/hypridle

--- a/hypr/hyprpicker.spec
+++ b/hypr/hyprpicker.spec
@@ -1,6 +1,6 @@
 Name:           hyprpicker
 Version:        0.4.7
-Release:        %autorelease
+Release:        %autorelease -b2
 Summary:        A wlroots-compatible Wayland color picker
 # LICENSE: BSD-3-Clause
 # protocols/wlr-layer-shell-unstable-v1.xml: HPND-sell-variant

--- a/hypr/hyprtoolkit.spec
+++ b/hypr/hyprtoolkit.spec
@@ -1,6 +1,6 @@
 Name:           hyprtoolkit
 Version:        0.5.4
-Release:        %autorelease
+Release:        %autorelease -b2
 Summary:        A modern C++ Wayland-native GUI toolkit
 
 License:        BSD-3-Clause


### PR DESCRIPTION
## Summary

- rebuild hypridle against the current hyprutils and hyprlang libraries
- rebuild hyprpicker against `libhyprutils.so.13`
- rebuild hyprtoolkit against the current hyprutils, aquamarine, hyprgraphics, and hyprlang libraries

## Ordering

Merge after aquamarine 0.14.0 and the hyprgraphics, hyprlang, and hyprwire foundation rebuilds are published in the Fedora 43/44 x86_64 COPR repositories. Hyprpaper remains deferred until this wave publishes.

## Verification

- `scripts/check-spec-guards.sh`
- `git diff --check`
- Fedora 43/44 package builds in PR CI