### PR TITLE
chore(hyprpaper): rebuild for hyprutils 0.14

### DIFF
--- a/hypr/hyprpaper.spec
+++ b/hypr/hyprpaper.spec
@@ -1,6 +1,6 @@
 Name:           hyprpaper
 Version:        0.8.4
-Release:        %autorelease
+Release:        %autorelease -b2
 Summary:        Blazing fast wayland wallpaper utility with IPC controls
 # LICENSE: BSD-3-Clause
 # protocols/wlr-layer-shell-unstable-v1.xml: HPND-sell-variant


### PR DESCRIPTION
## Summary

Rebuild hyprpaper against the completed Hypr ABI chain:

- hyprutils 0.14.0 / `libhyprutils.so.13`
- rebuilt hyprlang and hyprwire
- rebuilt hyprtoolkit against aquamarine 0.14.0

## Ordering

This is the final rebuild wave and is based on the merged Wave 3 consumer rebuilds.

## Verification

- `scripts/check-spec-guards.sh`
- `git diff --check`
- Fedora 43/44 package builds in PR CI