### PR TITLE
fix(ghostty): build against system fontconfig/freetype/harfbuzz

### DIFF
--- a/ghostty/ghostty.spec
+++ b/ghostty/ghostty.spec
@@ -1,6 +1,6 @@
 Name:           ghostty
 Version:        1.3.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Fast, feature-rich, and cross-platform terminal emulator that uses platform-native UI and GPU acceleration
 
 

--- a/ghostty/ghostty.spec
+++ b/ghostty/ghostty.spec
@@ -1,6 +1,6 @@
 Name:           ghostty
 Version:        1.3.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Fast, feature-rich, and cross-platform terminal emulator that uses platform-native UI and GPU acceleration
 
 
@@ -13,6 +13,7 @@ ExclusiveArch: x86_64 aarch64
 
 
 BuildRequires: blueprint-compiler
+BuildRequires: bzip2-devel
 BuildRequires: fontconfig-devel
 BuildRequires: freetype-devel
 BuildRequires: glib2-devel
@@ -58,9 +59,17 @@ This package provides the development files for libghostty-vt.
 
 
 %build
+# Link the system fontconfig/freetype/harfbuzz rather than letting zig vendor
+# them. Without -fsys=, zig statically links its own copies *and* exports their
+# symbols from the executable, while GTK4 separately pulls in the system libs.
+# The executable wins global symbol resolution, so GTK's Fc*/FT_*/hb_* calls are
+# interposed into the vendored copies while operating on system-lib state.
 DESTDIR=%{buildroot} zig build \
     --summary all \
     --prefix "%{_prefix}" \
+    -fsys=fontconfig \
+    -fsys=freetype \
+    -fsys=harfbuzz \
     -Dversion-string=%{version}-%{release} \
     -Doptimize=ReleaseFast \
     -Dcpu=baseline \


### PR DESCRIPTION
Fixes #548.

The spec already `BuildRequires:` and `Requires:` fontconfig, freetype and harfbuzz, but never passes the matching `-fsys=` flags to `zig build` — so zig statically vendors its own copies anyway, and GTK4 pulls in the system ones alongside them. Both live in the same address space, and because the executable exports the vendored symbols and wins global symbol resolution, GTK/pango/cairo calls to 602 `Fc*`/`FT_*`/`hb_*` entry points are interposed into the vendored code while operating on system-lib state.

The visible result is a renderer-thread crash a few times a day: GTK calls `FcInitReinitialize()` on a font-settings change, which destroys the fontconfig config and unmaps its cache pages while ghostty's renderer thread is inside `FcFontSort()` doing fallback lookup for a CJK/emoji codepoint. Full backtraces from both sides of the race, and the unmapped-page evidence, are in #548.

## Change

- `-fsys=fontconfig -fsys=freetype -fsys=harfbuzz` on the `zig build` line
- `BuildRequires: bzip2-devel` — `-fsys=freetype` makes `SharedDeps.zig:152` call `linkSystemLibrary2("bzip2")`, which needs `bzip2.pc`
- `Release: 2` → `3`

## Verification

Built with `rpmbuild -bb` on Fedora 44 and installed:

```console
$ for p in Fc FT_ hb_; do echo "$p: $(nm -D --defined-only /usr/bin/ghostty | grep -cE " [TWD] $p")"; done
Fc: 0        # was 27
FT_: 0       # was 57
hb_: 0       # was 518

$ for p in Fc FT_ hb_; do echo "$p: $(nm -D --undefined-only /usr/bin/ghostty | grep -cE " U $p")"; done
Fc: 18
FT_: 35
hb_: 15
```

RPM now grows real soname deps that the previous build lacked — `libfontconfig.so.1()(64bit)`, `libfreetype.so.6()(64bit)`, `libharfbuzz.so.0()(64bit)` — so there is exactly one of each library in the process.

Ghostty starts and renders normally, including CJK fallback (`fc-match :charset=5927` → Noto Sans CJK JP, the exact lookup in the crashing backtrace). I can't offer a long soak yet, but the collision the crash depends on is gone.

## Note on the build environment

`BuildRequires: zig` now resolves to zig 0.16.0 on Fedora 44, while ghostty 1.3.1 sets `minimum_zig_version = "0.15.2"`. I built with an upstream 0.15.2 tarball on `PATH`. That's independent of this change, but a rebuild of the current spec in COPR may hit it — mentioned in #548 rather than addressed here.
