### PR TITLE
 feat(ghostty): add Zig 0.15 package

### DIFF
--- a/ghostty/ghostty.spec
+++ b/ghostty/ghostty.spec
@@ -26,7 +26,7 @@ BuildRequires: pandoc-cli
 BuildRequires: pixman-devel
 BuildRequires: pkg-config
 BuildRequires: wayland-protocols-devel
-BuildRequires: zig
+BuildRequires: zig015 = 0.15.2
 BuildRequires: zlib-ng-devel
 
 

--- a/ghostty/ghostty.spec
+++ b/ghostty/ghostty.spec
@@ -1,6 +1,6 @@
 Name:           ghostty
 Version:        1.3.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Fast, feature-rich, and cross-platform terminal emulator that uses platform-native UI and GPU acceleration
 
 

--- a/ghostty/zig.spec
+++ b/ghostty/zig.spec
@@ -1,0 +1,61 @@
+%global debug_package %{nil}
+
+%ifarch x86_64
+%global zig_arch x86_64
+%global upstream_sha256 02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239
+%endif
+%ifarch aarch64
+%global zig_arch aarch64
+%global upstream_sha256 958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f
+%endif
+
+Name:           zig015
+Version:        0.15.2
+Release:        %autorelease
+Summary:        General-purpose programming language and toolchain
+
+License:        MIT
+URL:            https://ziglang.org
+Source0:        https://ziglang.org/download/%{version}/zig-%{zig_arch}-linux-%{version}.tar.xz
+
+ExclusiveArch:  x86_64 aarch64
+
+BuildRequires:  coreutils
+
+%description
+Zig is a general-purpose programming language and toolchain for maintaining
+robust, optimal, and reusable software.
+
+This package repackages the official upstream prebuilt compiler so Ghostty can
+be built with Zig %{version}, rather than Fedora's newer Zig release.
+
+%prep
+%setup -q -n zig-%{zig_arch}-linux-%{version}
+
+actual_sum="$(sha256sum %{SOURCE0} | cut -d' ' -f1)"
+if [ "%{upstream_sha256}" != "$actual_sum" ]; then
+    echo "ERROR: checksum verification failed for %{SOURCE0}" >&2
+    echo "Expected: %{upstream_sha256}" >&2
+    echo "Actual:   $actual_sum" >&2
+    exit 1
+fi
+
+%build
+# Upstream prebuilt compiler repackaging; nothing to build.
+
+%install
+install -Dpm 0755 zig %{buildroot}%{_bindir}/zig
+mkdir -p %{buildroot}%{_libdir}
+cp -a lib %{buildroot}%{_libdir}/zig
+
+%check
+test "$(%{buildroot}%{_bindir}/zig version)" = "%{version}"
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/zig
+%{_libdir}/zig/
+
+%changelog
+%autochangelog

--- a/ghostty/zig.spec
+++ b/ghostty/zig.spec
@@ -1,14 +1,5 @@
 %global debug_package %{nil}
 
-%ifarch x86_64
-%global zig_arch x86_64
-%global upstream_sha256 02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239
-%endif
-%ifarch aarch64
-%global zig_arch aarch64
-%global upstream_sha256 958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f
-%endif
-
 Name:           zig015
 Version:        0.15.2
 Release:        %autorelease
@@ -16,7 +7,17 @@ Summary:        General-purpose programming language and toolchain
 
 License:        MIT
 URL:            https://ziglang.org
-Source0:        https://ziglang.org/download/%{version}/zig-%{zig_arch}-linux-%{version}.tar.xz
+Source0:        https://ziglang.org/download/%{version}/zig-x86_64-linux-%{version}.tar.xz
+Source1:        https://ziglang.org/download/%{version}/zig-aarch64-linux-%{version}.tar.xz
+
+%ifarch x86_64
+%global upstream_source %{SOURCE0}
+%global upstream_sha256 02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239
+%endif
+%ifarch aarch64
+%global upstream_source %{SOURCE1}
+%global upstream_sha256 958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f
+%endif
 
 ExclusiveArch:  x86_64 aarch64
 
@@ -30,15 +31,17 @@ This package repackages the official upstream prebuilt compiler so Ghostty can
 be built with Zig %{version}, rather than Fedora's newer Zig release.
 
 %prep
-%setup -q -n zig-%{zig_arch}-linux-%{version}
+%setup -q -c -T -n zig-%{version}
 
-actual_sum="$(sha256sum %{SOURCE0} | cut -d' ' -f1)"
+actual_sum="$(sha256sum %{upstream_source} | cut -d' ' -f1)"
 if [ "%{upstream_sha256}" != "$actual_sum" ]; then
-    echo "ERROR: checksum verification failed for %{SOURCE0}" >&2
+    echo "ERROR: checksum verification failed for %{upstream_source}" >&2
     echo "Expected: %{upstream_sha256}" >&2
     echo "Actual:   $actual_sum" >&2
     exit 1
 fi
+
+tar -xf %{upstream_source} --strip-components=1
 
 %build
 # Upstream prebuilt compiler repackaging; nothing to build.

--- a/ghostty/zig.spec
+++ b/ghostty/zig.spec
@@ -48,8 +48,8 @@ tar -xf %{upstream_source} --strip-components=1
 
 %install
 install -Dpm 0755 zig %{buildroot}%{_bindir}/zig
-mkdir -p %{buildroot}%{_libdir}
-cp -a lib %{buildroot}%{_libdir}/zig
+mkdir -p %{buildroot}%{_prefix}/lib
+cp -a lib %{buildroot}%{_prefix}/lib/zig
 
 %check
 test "$(%{buildroot}%{_bindir}/zig version)" = "%{version}"
@@ -58,7 +58,7 @@ test "$(%{buildroot}%{_bindir}/zig version)" = "%{version}"
 %license LICENSE
 %doc README.md
 %{_bindir}/zig
-%{_libdir}/zig/
+%{_prefix}/lib/zig/
 
 %changelog
 %autochangelog


### PR DESCRIPTION
Adds new package [`zig015`](https://copr.fedorainfracloud.org/coprs/scottames/ghostty/package/zig015/) (named to avoid conflict with Fedora repos) to build Ghostty with the exact version necessary in this copr.