### PR TITLE
fix(vicinae): restore aarch64 COPR builds

### DIFF
--- a/vicinae/vicinae.spec
+++ b/vicinae/vicinae.spec
@@ -7,6 +7,7 @@ Version:        0.26.3
 Release:        1%{?dist}
 Summary:        A focused launcher for your desktop — native, fast, extensible
 License:        GPL-3.0
+ExclusiveArch:  x86_64 aarch64
 
 %forgemeta
 URL:            %{forgeurl}

--- a/vicinae/vicinae.spec
+++ b/vicinae/vicinae.spec
@@ -4,7 +4,7 @@
 Name:           vicinae
 Epoch:          1
 Version:        0.26.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A focused launcher for your desktop — native, fast, extensible
 License:        GPL-3.0
 ExclusiveArch:  x86_64 aarch64


### PR DESCRIPTION
## Summary

- declare `x86_64` and `aarch64` as Vicinae's supported RPM architectures
- let the existing COPR trigger submit Fedora 43 and 44 builds for both architectures

## Why

The explicit-chroot trigger defaults specs without architecture metadata to x86_64. Consequently, Vicinae's aarch64 builds stopped after the final manually submitted multi-architecture build for 0.20.14. The upstream project supports Linux arm64 and ships aarch64 releases.

No COPR chroot or build-target configuration changes are needed: the project already enables the Fedora 43/44 aarch64 chroots.

## Validation

- `scripts/check-spec-guards.sh`
- `git diff --check`
- confirmed the trigger resolves `fedora-43-{x86_64,aarch64}` and `fedora-44-{x86_64,aarch64}` from the spec metadata

Closes #571.