### PR TITLE
fix(ci): restore COPR aarch64 chroot inference

### DIFF
--- a/.github/workflows/trigger-copr-builds.yaml
+++ b/.github/workflows/trigger-copr-builds.yaml
@@ -88,7 +88,14 @@ jobs:
             fi
 
             SPEC_EXCLUSIVE_ARCHES="$(grep -Pom1 '^ExclusiveArch:\s*\K.*' "$COPR_SPEC_FILE" || true)"
-            SPEC_BUILD_ARCH="$(grep -Pom1 '^BuildArch:\s*\K[^[:space:]]+' "$COPR_SPEC_FILE" || true)"
+            SPEC_BUILD_ARCH="$(awk '
+              /^%package([[:space:]]|$)/ { exit }
+              /^BuildArch:[[:space:]]*/ {
+                sub(/^BuildArch:[[:space:]]*/, "")
+                print $1
+                exit
+              }
+            ' "$COPR_SPEC_FILE")"
             SPEC_IFARCH_ARCHES="$(grep -Po '^%ifarch\s+\K.*' "$COPR_SPEC_FILE" | tr ' ' '\n' | grep -E '^(x86_64|aarch64)$' | sort -u | xargs || true)"
 
             SPEC_ARCHES="x86_64"

--- a/vicinae/vicinae.spec
+++ b/vicinae/vicinae.spec
@@ -4,7 +4,7 @@
 Name:           vicinae
 Epoch:          1
 Version:        0.26.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A focused launcher for your desktop — native, fast, extensible
 License:        GPL-3.0
 ExclusiveArch:  x86_64 aarch64


### PR DESCRIPTION
## Summary

- inspect `BuildArch` only in a spec's main-package section
- preserve architecture inference for specs whose subpackages are `noarch`
- bump Vicinae to `0.26.3-3` so this merge triggers a fresh COPR build through the repaired workflow

## Why

The COPR trigger previously used the first `BuildArch:` in the entire spec. For Vicinae, that is `BuildArch: noarch` on the `icon-theme` subpackage, which overrode the main package's `ExclusiveArch: x86_64 aarch64`. As a result, COPR build 10908561 was submitted only to x86_64 chroots.

Stopping at the first `%package` directive keeps `BuildArch` scoped to the main package. Vicinae therefore falls through to its `ExclusiveArch` declaration and submits both x86_64 and aarch64 chroots. The release bump provides a new NVR to verify that behavior before merging the 0.27.1 Renovate update.

## Validation

- `actionlint .github/workflows/trigger-copr-builds.yaml`
- `scripts/check-spec-guards.sh`
- `git diff --check`
- exercised the inference logic against:
  - `vicinae/vicinae.spec` → `x86_64 aarch64`
  - `vicinae/glaze.spec` → `x86_64` (main package remains `noarch`)