### PR TITLE
feat(monstar): add source-built COPR package

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,13 @@
     },
   ],
   customDatasources: {
+    'monstar-source': {
+      defaultRegistryUrlTemplate: 'https://api.github.com/repos/rockorager/monstar/releases',
+      format: 'json',
+      transformTemplates: [
+        '($sourceName:=function($release){"monstar-" & $replace($release.tag_name,/^v/,"") & "-source.tar.gz"};$sourceAsset:=function($release){($filter($release.assets,function($asset){$asset.name=$sourceName($release) and $contains($asset.digest,/^sha256:[0-9a-f]{64}$/)}))[0]};{"releases":$append([],$map($filter($,function($release){$contains($release.tag_name,/^v/) and $not($release.draft) and $not($release.prerelease) and $exists($sourceAsset($release))}),function($release){($version:=$replace($release.tag_name,/^v/,"");$asset:=$sourceAsset($release);{"version":$version,"releaseTimestamp":$release.published_at,"changelogUrl":$release.html_url,"sourceUrl":$release.html_url,"digest":$replace($asset.digest,/^sha256:/,"")})})),"sourceUrl":"https://github.com/rockorager/monstar","homepage":"https://github.com/rockorager/monstar"})',
+      ],
+    },
     'voxtype-rpm': {
       defaultRegistryUrlTemplate: 'https://api.github.com/repos/peteonrails/voxtype/releases',
       format: 'json',
@@ -211,6 +218,18 @@
       ],
       depNameTemplate: 'jdx/mise',
       datasourceTemplate: 'github-releases',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^monstar/monstar\\.spec$/',
+      ],
+      matchStrings: [
+        '(?<checksumPrefix>%global\\s+upstream_source_sha256\\s+)(?<currentDigest>[0-9a-f]{64})(?<versionPrefix>\\n(?:.*\\n)*?Version:\\s*)(?<currentValue>\\S+)',
+      ],
+      depNameTemplate: 'rockorager/monstar',
+      datasourceTemplate: 'custom.monstar-source',
+      versioningTemplate: 'semver',
     },
     {
       customType: 'regex',

--- a/.github/workflows/spec-guards.yaml
+++ b/.github/workflows/spec-guards.yaml
@@ -8,6 +8,7 @@ on:
       - scripts/check-spec-guards.sh
       - scripts/fix-spec-guards.sh
       - scripts/test-check-spec-guards.sh
+      - scripts/test-monstar-renovate-checksum.sh
       - scripts/test-spec-helper-scripts.sh
       - scripts/test-voxtype-renovate-checksum.sh
       - scripts/test-zennotes-renovate-checksum.sh
@@ -37,6 +38,8 @@ jobs:
         run: scripts/test-check-spec-guards.sh
       - name: Run spec helper tests
         run: scripts/test-spec-helper-scripts.sh
+      - name: Run Monstar Renovate checksum tests
+        run: scripts/test-monstar-renovate-checksum.sh
       - name: Run Voxtype Renovate checksum tests
         run: scripts/test-voxtype-renovate-checksum.sh
       - name: Run ZenNotes Renovate checksum tests

--- a/monstar/README.md
+++ b/monstar/README.md
@@ -1,0 +1,46 @@
+# monstar
+
+[![Powered By: Copr](https://img.shields.io/badge/Powered_by-COPR-blue?style=flat-square)](https://copr.fedorainfracloud.org/)
+![Architectures: x86_64, aarch64](https://img.shields.io/badge/Architectures-x86__64%2C_aarch64-blue?style=flat-square)
+[![Latest Version](https://img.shields.io/badge/dynamic/json?color=blue&label=Version&query=builds.latest.source_package.version&url=https%3A%2F%2Fcopr.fedorainfracloud.org%2Fapi_3%2Fpackage%3Fownername%3Dscottames%26projectname%3Dmonstar%26packagename%3Dmonstar%26with_latest_build%3DTrue&style=flat-square&logoColor=blue)](https://copr.fedorainfracloud.org/coprs/scottames/monstar/package/monstar/)
+[![Copr build status](https://copr.fedorainfracloud.org/coprs/scottames/monstar/package/monstar/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/scottames/monstar/package/monstar/)
+
+## About
+
+[Monstar](https://github.com/rockorager/monstar) is a Linux-native Wayland
+terminal built on the Ghostty terminal core. This package builds Monstar from
+the source archive attached to its GitHub releases and publishes it to
+[Copr](https://copr.fedorainfracloud.org/coprs/scottames/monstar).
+
+>[!WARNING]
+> This Copr is intended for my personal use only. Use at your own risk.
+>
+> The upstream source archive does not vendor its Zig dependencies, so the Copr
+> project must allow network access during builds.
+
+### Bugs
+
+- Application bugs should be reported to the
+  [Monstar GitHub repository](https://github.com/rockorager/monstar/issues).
+- Packaging bugs should be reported to
+  [this GitHub project](https://github.com/scottames/copr/issues).
+
+## Installation
+
+1. Enable the Copr repository:
+
+```bash
+sudo dnf copr enable scottames/monstar
+```
+
+2. Install Monstar:
+
+```bash
+sudo dnf install monstar
+```
+
+## Updating
+
+```bash
+sudo dnf upgrade monstar
+```

--- a/monstar/monstar-1.0.1-zig-linker-aarch64.patch
+++ b/monstar/monstar-1.0.1-zig-linker-aarch64.patch
@@ -1,0 +1,10 @@
+diff --git a/build.zig b/build.zig
+--- a/build.zig
++++ b/build.zig
+@@ -124,3 +124,6 @@
+         .use_llvm = true,
++        // Zig's bundled LLD cannot resolve Fedora's versioned glibc symbols
++        // on aarch64.
++        .use_lld = false,
+     });
+     root_module.addCSourceFile(.{ .file = b.path("vendor/stb_image_resize.c") });

--- a/monstar/monstar.spec
+++ b/monstar/monstar.spec
@@ -1,0 +1,69 @@
+%global upstream_source_sha256 a82209aaef3534407f29d860e3174974f19b4a7c10286212fdeacdcd1cb9049d
+
+Name:           monstar
+Version:        1.0.1
+Release:        %autorelease
+Summary:        Linux-native Wayland terminal built on the Ghostty terminal core
+
+License:        MIT
+URL:            https://github.com/rockorager/monstar
+Source0:        https://github.com/rockorager/monstar/releases/download/v%{version}/monstar-%{version}-source.tar.gz
+
+ExclusiveArch:  x86_64 aarch64
+
+BuildRequires:  coreutils
+BuildRequires:  fontconfig-devel
+BuildRequires:  freetype-devel
+BuildRequires:  git-core
+BuildRequires:  harfbuzz-devel
+BuildRequires:  libxkbcommon-devel
+BuildRequires:  ncurses
+BuildRequires:  pkg-config
+BuildRequires:  wayland-devel >= 1.25
+BuildRequires:  wayland-protocols-devel >= 1.49
+BuildRequires:  zig >= 0.16.0
+
+%description
+Monstar is a terminal emulator for Linux and Wayland built on the Ghostty
+terminal core. It supports fractional scaling, text input, desktop
+notifications, Kitty graphics, scrollback search, and bundled color schemes.
+
+%prep
+actual_sum="$(sha256sum %{SOURCE0} | cut -d' ' -f1)"
+if [ "%{upstream_source_sha256}" != "$actual_sum" ]; then
+    echo "ERROR: checksum verification failed for %{SOURCE0}" >&2
+    echo "Expected: %{upstream_source_sha256}" >&2
+    echo "Actual:   $actual_sum" >&2
+    exit 1
+fi
+
+%autosetup -n %{name}-%{version}
+
+%build
+# The release source archive does not vendor the Zig dependency tree.
+zig build --fetch=all
+zig build \
+    --summary all \
+    --build-id=sha1 \
+    -Doptimize=ReleaseFast \
+    -Dcpu=baseline
+
+%install
+mkdir -p %{buildroot}%{_prefix}
+cp -a zig-out/. %{buildroot}%{_prefix}/
+
+%check
+test "$(%{buildroot}%{_bindir}/monstar --version)" = "monstar %{version}"
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/monstar
+%{_datadir}/applications/dev.rockorager.monstar.desktop
+%{_datadir}/icons/hicolor/scalable/apps/dev.rockorager.monstar.svg
+%{_datadir}/monstar/
+%{_mandir}/man1/monstar.1*
+%{_mandir}/man5/monstar.5*
+
+%changelog
+%autochangelog

--- a/monstar/monstar.spec
+++ b/monstar/monstar.spec
@@ -1,4 +1,5 @@
 %global upstream_source_sha256 a82209aaef3534407f29d860e3174974f19b4a7c10286212fdeacdcd1cb9049d
+%global debug_package %{nil}
 
 Name:           monstar
 Version:        1.0.1
@@ -8,6 +9,8 @@ Summary:        Linux-native Wayland terminal built on the Ghostty terminal core
 License:        MIT
 URL:            https://github.com/rockorager/monstar
 Source0:        https://github.com/rockorager/monstar/releases/download/v%{version}/monstar-%{version}-source.tar.gz
+# patch-guard: remove-after-version=1.0.1 reason=zig-lld-aarch64-glibc-symbols
+Patch0:         monstar-1.0.1-zig-linker-aarch64.patch
 
 ExclusiveArch:  x86_64 aarch64
 
@@ -37,14 +40,13 @@ if [ "%{upstream_source_sha256}" != "$actual_sum" ]; then
     exit 1
 fi
 
-%autosetup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-%{version}
 
 %build
 # The release source archive does not vendor the Zig dependency tree.
 zig build --fetch=all
 zig build \
     --summary all \
-    --build-id=sha1 \
     -Doptimize=ReleaseFast \
     -Dcpu=baseline
 

--- a/scripts/test-monstar-renovate-checksum.sh
+++ b/scripts/test-monstar-renovate-checksum.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+failures=0
+
+assert_grep() {
+    local pattern=$1
+    local file=$2
+    local message=$3
+
+    if grep -Eq "$pattern" "$file"; then
+        printf 'ok - %s\n' "$message"
+    else
+        printf 'not ok - %s\n' "$message"
+        failures=$((failures + 1))
+    fi
+}
+
+assert_grep '^%global[[:space:]]+upstream_source_sha256[[:space:]]+[0-9a-f]{64}$' \
+    monstar/monstar.spec \
+    'monstar spec pins the upstream source sha256'
+assert_grep '%\{upstream_source_sha256\}' \
+    monstar/monstar.spec \
+    'monstar prep verifies the pinned source sha256'
+assert_grep 'releases/download/v%\{version\}/monstar-%\{version\}-source\.tar\.gz' \
+    monstar/monstar.spec \
+    'monstar spec uses the versioned release source asset'
+
+assert_grep "datasourceTemplate: 'custom\.monstar-source'" \
+    .github/renovate.json5 \
+    'renovate uses the Monstar source custom datasource'
+assert_grep 'currentDigest' \
+    .github/renovate.json5 \
+    'renovate captures the current source sha256 digest'
+assert_grep 'sourceName:=function.*-source\.tar\.gz' \
+    .github/renovate.json5 \
+    'renovate filters releases to the matching source asset'
+assert_grep 'sha256:\[0-9a-f\]\{64\}' \
+    .github/renovate.json5 \
+    'renovate requires a valid source asset digest'
+assert_grep "\"releases\":\\\$append\\(\\[\\],\\\$map" \
+    .github/renovate.json5 \
+    'renovate preserves an array when only one release matches'
+
+exit "$failures"


### PR DESCRIPTION
## Summary
- package Monstar 1.0.1 from its checksum-verified upstream source archive
- track matching release assets and SHA-256 digests through Renovate with regression coverage
- support x86_64 and aarch64; use Zig's non-LLD linker on aarch64 and omit the unavailable debuginfo subpackage

## Validation
- scripts/test-check-spec-guards.sh
- scripts/test-spec-helper-scripts.sh
- scripts/check-spec-guards.sh
- scripts/test-monstar-renovate-checksum.sh
- shellcheck scripts/*.sh
- actionlint .github/workflows/spec-guards.yaml
- patch --dry-run --fuzz=0 against the Monstar 1.0.1 source archive

## Notes
- The source archive fetches Zig dependencies during the build, so COPR network access is required.
- A final remote COPR build is still needed to validate the current debuginfo workaround on both architectures.